### PR TITLE
Data-Driven Item Attribute Modifiers

### DIFF
--- a/src/main/java/com/github/thedeathlycow/frostiful/init/Frostiful.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/init/Frostiful.java
@@ -9,6 +9,7 @@ import com.github.thedeathlycow.frostiful.entity.damage.FDamageSource;
 import com.github.thedeathlycow.frostiful.entity.effect.FStatusEffects;
 import com.github.thedeathlycow.frostiful.entity.loot.StrayLootTableModifier;
 import com.github.thedeathlycow.frostiful.item.FItems;
+import com.github.thedeathlycow.frostiful.item.attribute.ItemAttributeLoader;
 import com.github.thedeathlycow.frostiful.particle.FParticleTypes;
 import com.github.thedeathlycow.frostiful.server.command.FrostCommand;
 import com.github.thedeathlycow.frostiful.server.command.FrostifulCommand;
@@ -48,7 +49,11 @@ public class Frostiful implements ModInitializer {
 
         LootTableEvents.MODIFY.register(StrayLootTableModifier::addFrostTippedArrows);
         TemperatureEffects.createEffectTypes();
-        ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(TemperatureEffectLoader.INSTANCE);
+
+        ResourceManagerHelper serverManager = ResourceManagerHelper.get(ResourceType.SERVER_DATA);
+
+        serverManager.registerReloadListener(TemperatureEffectLoader.INSTANCE);
+        serverManager.registerReloadListener(ItemAttributeLoader.INSTANCE);
 
         FEntityAttributes.registerAttributes();
         FDamageSource.registerDamageSources();

--- a/src/main/java/com/github/thedeathlycow/frostiful/item/attribute/AttributeHolder.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/item/attribute/AttributeHolder.java
@@ -1,0 +1,35 @@
+package com.github.thedeathlycow.frostiful.item.attribute;
+
+import com.github.thedeathlycow.frostiful.util.FJsonHelper;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+import java.util.UUID;
+
+public record AttributeHolder(
+        EntityAttribute attribute,
+        EntityAttributeModifier modifier
+) {
+
+    public static AttributeHolder fromJson(JsonElement jsonElement) throws JsonSyntaxException {
+        JsonObject json = jsonElement.getAsJsonObject();
+
+        Identifier attributeID = new Identifier(json.get("attribute").getAsString());
+
+        if (!Registry.ATTRIBUTE.containsId(attributeID)) {
+            throw new JsonSyntaxException("Unknown entity attribute: '" + attributeID + "'");
+        }
+
+        EntityAttribute attribute = Registry.ATTRIBUTE.get(attributeID);
+
+        EntityAttributeModifier modifier = FJsonHelper.parseAttributeModifier(json.get("modifier"));
+
+        return new AttributeHolder(attribute, modifier);
+    }
+
+}

--- a/src/main/java/com/github/thedeathlycow/frostiful/item/attribute/AttributeLoader.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/item/attribute/AttributeLoader.java
@@ -1,0 +1,4 @@
+package com.github.thedeathlycow.frostiful.item.attribute;
+
+public class AttributeLoader {
+}

--- a/src/main/java/com/github/thedeathlycow/frostiful/item/attribute/AttributeLoader.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/item/attribute/AttributeLoader.java
@@ -1,4 +1,0 @@
-package com.github.thedeathlycow.frostiful.item.attribute;
-
-public class AttributeLoader {
-}

--- a/src/main/java/com/github/thedeathlycow/frostiful/item/attribute/ItemAttributeLoader.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/item/attribute/ItemAttributeLoader.java
@@ -1,18 +1,23 @@
 package com.github.thedeathlycow.frostiful.item.attribute;
 
 import com.github.thedeathlycow.frostiful.init.Frostiful;
+import com.google.common.collect.Multimap;
 import com.google.gson.JsonParseException;
+import net.fabricmc.fabric.api.item.v1.ModifyItemAttributeModifiersCallback;
 import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.item.ItemStack;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ItemAttributeLoader implements SimpleSynchronousResourceReloadListener {
+public class ItemAttributeLoader implements SimpleSynchronousResourceReloadListener, ModifyItemAttributeModifiersCallback {
 
     public static final ItemAttributeLoader INSTANCE = new ItemAttributeLoader(Frostiful.id("item_attribute_modifiers"));
 
@@ -22,6 +27,8 @@ public class ItemAttributeLoader implements SimpleSynchronousResourceReloadListe
 
     public ItemAttributeLoader(Identifier identifier) {
         this.identifier = identifier;
+
+        ModifyItemAttributeModifiersCallback.EVENT.register(this);
     }
 
     @Override
@@ -47,7 +54,7 @@ public class ItemAttributeLoader implements SimpleSynchronousResourceReloadListe
             }
         }
 
-        this.clearValues();
+        this.values.clear();
         this.values.putAll(newValues);
 
         int numModifiers = this.values.size();
@@ -55,15 +62,10 @@ public class ItemAttributeLoader implements SimpleSynchronousResourceReloadListe
 
     }
 
-    private void clearValues() {
-
-        this.values.values().forEach(ItemAttributeModifier::disable);
-
-        this.values.clear();
-    }
-
-    @Nullable
-    public ItemAttributeModifier get(Identifier id) {
-        return this.values.getOrDefault(id, null);
+    @Override
+    public void modifyAttributeModifiers(ItemStack stack, EquipmentSlot slot, Multimap<EntityAttribute, EntityAttributeModifier> attributeModifiers) {
+        for (var value : this.values.values()) {
+            value.apply(stack, slot, attributeModifiers);
+        }
     }
 }

--- a/src/main/java/com/github/thedeathlycow/frostiful/item/attribute/ItemAttributeLoader.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/item/attribute/ItemAttributeLoader.java
@@ -1,0 +1,69 @@
+package com.github.thedeathlycow.frostiful.item.attribute;
+
+import com.github.thedeathlycow.frostiful.init.Frostiful;
+import com.google.gson.JsonParseException;
+import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ItemAttributeLoader implements SimpleSynchronousResourceReloadListener {
+
+    public static final ItemAttributeLoader INSTANCE = new ItemAttributeLoader(Frostiful.id("item_attribute_modifiers"));
+
+    private final Identifier identifier;
+
+    private final Map<Identifier, ItemAttributeModifier> values = new HashMap<>();
+
+    public ItemAttributeLoader(Identifier identifier) {
+        this.identifier = identifier;
+    }
+
+    @Override
+    public Identifier getFabricId() {
+        return this.identifier;
+    }
+
+    @Override
+    public void reload(ResourceManager manager) {
+        Map<Identifier, ItemAttributeModifier> newValues = new HashMap<>();
+
+        for (var entry : manager.findResources("frostiful/item_attribute_modifiers", id -> id.getPath().endsWith(".json")).entrySet()) {
+            try (BufferedReader reader = entry.getValue().getReader()) {
+
+                ItemAttributeModifier modifier = ItemAttributeModifier.Serializer.GSON.fromJson(
+                        reader,
+                        ItemAttributeModifier.class
+                );
+
+                newValues.put(entry.getKey(), modifier);
+            } catch (IOException | JsonParseException e) {
+                Frostiful.LOGGER.error("An error occurred while loading item attribute modifier {}: {}", entry.getKey(), e);
+            }
+        }
+
+        this.clearValues();
+        this.values.putAll(newValues);
+
+        int numModifiers = this.values.size();
+        Frostiful.LOGGER.info("Loaded {} item attribute modifier{}", numModifiers, numModifiers == 1 ? "" : "s");
+
+    }
+
+    private void clearValues() {
+
+        this.values.values().forEach(ItemAttributeModifier::disable);
+
+        this.values.clear();
+    }
+
+    @Nullable
+    public ItemAttributeModifier get(Identifier id) {
+        return this.values.getOrDefault(id, null);
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/frostiful/item/attribute/ItemAttributeModifier.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/item/attribute/ItemAttributeModifier.java
@@ -1,0 +1,96 @@
+package com.github.thedeathlycow.frostiful.item.attribute;
+
+import com.google.common.collect.Multimap;
+import com.google.gson.*;
+import net.fabricmc.fabric.api.item.v1.ModifyItemAttributeModifiersCallback;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ItemAttributeModifier {
+    private final Item item;
+    private final EquipmentSlot slot;
+    private final List<AttributeHolder> attributeModifiers;
+
+    private boolean isEnabled = true;
+
+    public ItemAttributeModifier(
+            Item item,
+            EquipmentSlot slot,
+            List<AttributeHolder> attributeModifiers
+    ) {
+        this.item = item;
+        this.slot = slot;
+        this.attributeModifiers = attributeModifiers;
+
+        ModifyItemAttributeModifiersCallback.EVENT.register(this::apply);
+    }
+
+    public void apply(ItemStack stack, EquipmentSlot slot, Multimap<EntityAttribute, EntityAttributeModifier> attributeModifiers) {
+        if (this.isEnabled && stack.isOf(this.item) && slot == this.slot) {
+            for (AttributeHolder holder : this.attributeModifiers) {
+                attributeModifiers.put(holder.attribute(), holder.modifier());
+            }
+        }
+    }
+
+    public void disable() {
+        this.isEnabled = false;
+    }
+
+    public static class Serializer implements JsonDeserializer<ItemAttributeModifier> {
+
+        public static final Gson GSON = new GsonBuilder()
+                .registerTypeAdapter(ItemAttributeModifier.class, new Serializer())
+                .create();
+
+        @Override
+        public ItemAttributeModifier deserialize(JsonElement jsonElement, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            JsonObject json = jsonElement.getAsJsonObject();
+
+            // parse item
+            Identifier itemID = new Identifier(json.get("item").getAsString());
+            if (!Registry.ITEM.containsId(itemID)) {
+                throw new JsonSyntaxException("Unknown item '" + itemID + "'");
+            }
+            Item item = Registry.ITEM.get(itemID);
+
+            // parse slot
+
+            EquipmentSlot slot;
+            String slotName = json.get("slot").getAsString();
+            try {
+                slot = EquipmentSlot.byName(slotName);
+            } catch (IllegalArgumentException e) {
+                throw new JsonSyntaxException("Unknown slot name '" + slotName + "'");
+            }
+
+            // parse modifiers
+            JsonElement attributesJson = json.get("attribute_modifiers");
+            List<AttributeHolder> attributeModifiers;
+
+            if (attributesJson.isJsonObject()) {
+                attributeModifiers = Collections.singletonList(AttributeHolder.fromJson(attributesJson));
+            } else if (attributesJson.isJsonArray()) {
+                attributeModifiers = new ArrayList<>();
+                for (JsonElement attributeModifier :  attributesJson.getAsJsonArray()) {
+                    attributeModifiers.add(AttributeHolder.fromJson(attributeModifier));
+                }
+            } else {
+                throw new JsonSyntaxException("Malformed item attribute modifiers:\n" + attributesJson.toString());
+            }
+
+            return new ItemAttributeModifier(item, slot, attributeModifiers);
+        }
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/frostiful/item/attribute/ItemAttributeModifier.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/item/attribute/ItemAttributeModifier.java
@@ -22,7 +22,6 @@ public class ItemAttributeModifier {
     private final EquipmentSlot slot;
     private final List<AttributeHolder> attributeModifiers;
 
-    private boolean isEnabled = true;
 
     public ItemAttributeModifier(
             Item item,
@@ -32,20 +31,14 @@ public class ItemAttributeModifier {
         this.item = item;
         this.slot = slot;
         this.attributeModifiers = attributeModifiers;
-
-        ModifyItemAttributeModifiersCallback.EVENT.register(this::apply);
     }
 
     public void apply(ItemStack stack, EquipmentSlot slot, Multimap<EntityAttribute, EntityAttributeModifier> attributeModifiers) {
-        if (this.isEnabled && stack.isOf(this.item) && slot == this.slot) {
+        if (stack.isOf(this.item) && slot == this.slot) {
             for (AttributeHolder holder : this.attributeModifiers) {
                 attributeModifiers.put(holder.attribute(), holder.modifier());
             }
         }
-    }
-
-    public void disable() {
-        this.isEnabled = false;
     }
 
     public static class Serializer implements JsonDeserializer<ItemAttributeModifier> {

--- a/src/main/java/com/github/thedeathlycow/frostiful/mixins/item/ArmorItemMixin.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/mixins/item/ArmorItemMixin.java
@@ -23,9 +23,8 @@ import java.util.UUID;
 @Mixin(ArmorItem.class)
 public class ArmorItemMixin {
 
-    @Shadow
-    @Final
-    private static UUID[] MODIFIERS;
+
+    private static final UUID[] frostiful$MODIFIERS = new UUID[]{UUID.fromString("43ce6852-f0e9-48b5-a451-f6d458f835a2"), UUID.fromString("015a4e56-3db0-45e7-a14c-82ebc3af86b5"), UUID.fromString("99cdd997-74a7-4427-a272-4f2e65c7d5d1"), UUID.fromString("87102398-36e2-4704-91c4-f2af697928ec")};
 
     @Shadow
     @Final
@@ -37,7 +36,7 @@ public class ArmorItemMixin {
             at = @At("RETURN")
     )
     private void addFrostResistanceToFurLinedArmour(ArmorMaterial material, EquipmentSlot slot, Item.Settings settings, CallbackInfo ci) {
-        UUID uUID = MODIFIERS[slot.getEntitySlotId()];
+        UUID uUID = frostiful$MODIFIERS[slot.getEntitySlotId()];
 
         if (material instanceof FrostResistantArmorMaterial frostResistantArmorMaterial) {
             ImmutableMultimap.Builder<EntityAttribute, EntityAttributeModifier> builder = ImmutableMultimap.builder();

--- a/src/main/java/com/github/thedeathlycow/frostiful/util/FJsonHelper.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/util/FJsonHelper.java
@@ -1,0 +1,37 @@
+package com.github.thedeathlycow.frostiful.util;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+
+import java.util.UUID;
+
+public final class FJsonHelper {
+
+
+    public static EntityAttributeModifier parseAttributeModifier(JsonElement jsonElement) throws JsonParseException {
+        JsonObject json = jsonElement.getAsJsonObject();
+
+        double value = json.get("value").getAsDouble();
+        UUID uuid = UUID.fromString(json.get("uuid").getAsString());
+
+        EntityAttributeModifier.Operation operation;
+        String operationName = json.get("operation").getAsString();
+        try {
+            operation = EntityAttributeModifier.Operation.valueOf(operationName.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new JsonSyntaxException("Unknown attribute operation: '" + operationName + "'");
+        }
+
+        String name = "";
+        if (json.has("name")) {
+            name = json.get("name").getAsString();
+        }
+
+        return new EntityAttributeModifier(uuid, name, value, operation);
+    }
+
+
+}

--- a/src/main/resources/data/frostiful/frostiful/item_attribute_modifiers/base_fur/fur_boots.json
+++ b/src/main/resources/data/frostiful/frostiful/item_attribute_modifiers/base_fur/fur_boots.json
@@ -1,0 +1,22 @@
+{
+	"item": "frostiful:fur_boots",
+	"slot": "feet",
+	"attribute_modifiers": [
+		{
+			"attribute": "minecraft:generic.armor",
+			"modifier": {
+				"uuid": "845DB27C-C624-495F-8C9F-6020A9A58B6B",
+				"value": 1.0,
+				"operation": "addition"
+			}
+		},
+		{
+			"attribute": "frostiful:generic.frost_resistance",
+			"modifier": {
+				"uuid": "43ce6852-f0e9-48b5-a451-f6d458f835a2",
+				"value": 0.5,
+				"operation": "addition"
+			}
+		}
+	]
+}

--- a/src/main/resources/data/frostiful/frostiful/item_attribute_modifiers/base_fur/fur_chestplate.json
+++ b/src/main/resources/data/frostiful/frostiful/item_attribute_modifiers/base_fur/fur_chestplate.json
@@ -1,0 +1,22 @@
+{
+	"item": "frostiful:fur_chestplate",
+	"slot": "chest",
+	"attribute_modifiers": [
+		{
+			"attribute": "minecraft:generic.armor",
+			"modifier": {
+				"uuid": "9F3D476D-C118-4544-8365-64846904B48E",
+				"value": 3.0,
+				"operation": "addition"
+			}
+		},
+		{
+			"attribute": "frostiful:generic.frost_resistance",
+			"modifier": {
+				"uuid": "99cdd997-74a7-4427-a272-4f2e65c7d5d1",
+				"value": 2.0,
+				"operation": "addition"
+			}
+		}
+	]
+}

--- a/src/main/resources/data/frostiful/frostiful/item_attribute_modifiers/base_fur/fur_helmet.json
+++ b/src/main/resources/data/frostiful/frostiful/item_attribute_modifiers/base_fur/fur_helmet.json
@@ -1,0 +1,22 @@
+{
+	"item": "frostiful:fur_helmet",
+	"slot": "head",
+	"attribute_modifiers": [
+		{
+			"attribute": "minecraft:generic.armor",
+			"modifier": {
+				"uuid": "2AD3F246-FEE1-4E67-B886-69FD380BB150",
+				"value": 1.0,
+				"operation": "addition"
+			}
+		},
+		{
+			"attribute": "frostiful:generic.frost_resistance",
+			"modifier": {
+				"uuid": "87102398-36e2-4704-91c4-f2af697928ec",
+				"value": 1.5,
+				"operation": "addition"
+			}
+		}
+	]
+}

--- a/src/main/resources/data/frostiful/frostiful/item_attribute_modifiers/base_fur/fur_leggings.json
+++ b/src/main/resources/data/frostiful/frostiful/item_attribute_modifiers/base_fur/fur_leggings.json
@@ -1,0 +1,22 @@
+{
+	"item": "frostiful:fur_leggings",
+	"slot": "legs",
+	"attribute_modifiers": [
+		{
+			"attribute": "minecraft:generic.armor",
+			"modifier": {
+				"uuid": "D8499B04-0E66-4726-AB29-64469D734E0D",
+				"value": 2.0,
+				"operation": "addition"
+			}
+		},
+		{
+			"attribute": "frostiful:generic.frost_resistance",
+			"modifier": {
+				"uuid": "015a4e56-3db0-45e7-a14c-82ebc3af86b5",
+				"value": 1.0,
+				"operation": "addition"
+			}
+		}
+	]
+}

--- a/src/main/resources/data/frostiful/frostiful/item_attribute_modifiers/fur_padded_chainmail/fur_padded_chainmail_boots.json
+++ b/src/main/resources/data/frostiful/frostiful/item_attribute_modifiers/fur_padded_chainmail/fur_padded_chainmail_boots.json
@@ -1,0 +1,22 @@
+{
+	"item": "frostiful:fur_padded_chainmail_boots",
+	"slot": "feet",
+	"attribute_modifiers": [
+		{
+			"attribute": "minecraft:generic.armor",
+			"modifier": {
+				"uuid": "845DB27C-C624-495F-8C9F-6020A9A58B6B",
+				"value": 1.0,
+				"operation": "addition"
+			}
+		},
+		{
+			"attribute": "frostiful:generic.frost_resistance",
+			"modifier": {
+				"uuid": "43ce6852-f0e9-48b5-a451-f6d458f835a2",
+				"value": 0.5,
+				"operation": "addition"
+			}
+		}
+	]
+}

--- a/src/main/resources/data/frostiful/frostiful/item_attribute_modifiers/fur_padded_chainmail/fur_padded_chainmail_chestplate.json
+++ b/src/main/resources/data/frostiful/frostiful/item_attribute_modifiers/fur_padded_chainmail/fur_padded_chainmail_chestplate.json
@@ -1,0 +1,22 @@
+{
+	"item": "frostiful:fur_padded_chainmail_chestplate",
+	"slot": "chest",
+	"attribute_modifiers": [
+		{
+			"attribute": "minecraft:generic.armor",
+			"modifier": {
+				"uuid": "9F3D476D-C118-4544-8365-64846904B48E",
+				"value": 5.0,
+				"operation": "addition"
+			}
+		},
+		{
+			"attribute": "frostiful:generic.frost_resistance",
+			"modifier": {
+				"uuid": "99cdd997-74a7-4427-a272-4f2e65c7d5d1",
+				"value": 2.0,
+				"operation": "addition"
+			}
+		}
+	]
+}

--- a/src/main/resources/data/frostiful/frostiful/item_attribute_modifiers/fur_padded_chainmail/fur_padded_chainmail_helmet.json
+++ b/src/main/resources/data/frostiful/frostiful/item_attribute_modifiers/fur_padded_chainmail/fur_padded_chainmail_helmet.json
@@ -1,0 +1,22 @@
+{
+	"item": "frostiful:fur_padded_chainmail_helmet",
+	"slot": "head",
+	"attribute_modifiers": [
+		{
+			"attribute": "minecraft:generic.armor",
+			"modifier": {
+				"uuid": "2AD3F246-FEE1-4E67-B886-69FD380BB150",
+				"value": 2.0,
+				"operation": "addition"
+			}
+		},
+		{
+			"attribute": "frostiful:generic.frost_resistance",
+			"modifier": {
+				"uuid": "87102398-36e2-4704-91c4-f2af697928ec",
+				"value": 1.5,
+				"operation": "addition"
+			}
+		}
+	]
+}

--- a/src/main/resources/data/frostiful/frostiful/item_attribute_modifiers/fur_padded_chainmail/fur_padded_chainmail_leggings.json
+++ b/src/main/resources/data/frostiful/frostiful/item_attribute_modifiers/fur_padded_chainmail/fur_padded_chainmail_leggings.json
@@ -1,0 +1,22 @@
+{
+	"item": "frostiful:fur_padded_chainmail_leggings",
+	"slot": "legs",
+	"attribute_modifiers": [
+		{
+			"attribute": "minecraft:generic.armor",
+			"modifier": {
+				"uuid": "D8499B04-0E66-4726-AB29-64469D734E0D",
+				"value": 4.0,
+				"operation": "addition"
+			}
+		},
+		{
+			"attribute": "frostiful:generic.frost_resistance",
+			"modifier": {
+				"uuid": "015a4e56-3db0-45e7-a14c-82ebc3af86b5",
+				"value": 1.0,
+				"operation": "addition"
+			}
+		}
+	]
+}


### PR DESCRIPTION
Implements #16 by allowing any item to be configured with any attribute modifier via a datapack. 

Item attribute modifiers are specified in the directory `data/[namespace]/frostiful/item_attribute_modifiers` in a JSON file with the following format:
```json
{
	"item": "Resource Location of Item to modify",
	"slot": "The string name of the slot to apply this to",
	"attribute_modifiers": [ 
		{
			"attribute": "Resource Location of the attribute to use for the modifier",
			"modifier": {
				"uuid": "A string UUID of the modifier",
				"operation": "The string name of the operation to use",
				"value": "The double value of the modifier",
				"name": "An optional string containing the name of the modifier. Defaults to the empty string".
			}
		}
	]
}
```

The `attribute_modifiers` field may either be specified as a JSON list or a JSON object