### PR TITLE
Better Scorchful integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.2-SNAPSHOT'
+    id 'fabric-loom' version '1.5-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ archives_base_name = frostiful
 # Dependencies
 
 # actually fabric api
-fabric_version=0.92.0+1.20.1
+fabric_version=0.91.0+1.20.1
 
 mod_menu_version=7.1.0
 cloth_config_version=11.0.99

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,8 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/develop
 minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.5
-loader_version=0.14.21
-
-
+yarn_mappings=1.20.1+build.10
+loader_version=0.15.7
 
 # Mod Properties
 mod_version = 1.0.4
@@ -17,7 +15,7 @@ archives_base_name = frostiful
 # Dependencies
 
 # actually fabric api
-fabric_version=0.84.0+1.20.1
+fabric_version=0.92.0+1.20.1
 
 mod_menu_version=7.1.0
 cloth_config_version=11.0.99

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ cloth_config_version=11.0.99
 fabric_asm_version=2.3
 
 # Thermoo
-thermoo_version=v2.1.0
+thermoo_version=v2.1.2
 
 # Colorful Hearts
 # https://modrinth.com/mod/colorful-hearts

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.20.1+build.10
 loader_version=0.15.7
 
 # Mod Properties
-mod_version = 1.0.4
+mod_version = 1.0.5
 maven_group = com.github.thedeathlycow
 archives_base_name = frostiful
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/github/thedeathlycow/frostiful/Frostiful.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/Frostiful.java
@@ -83,13 +83,13 @@ public class Frostiful implements ModInitializer {
         PlayerEnvironmentEvents.CAN_APPLY_PASSIVE_TEMPERATURE_CHANGE.register(
                 (change, player) -> {
 
-                    if (change > 0 || player.thermoo$isWarm()) {
+                    if (change > 0 && player.thermoo$isWarm()) {
                         return true;
                     }
 
                     FrostifulConfig config = getConfig();
 
-                    if (player.thermoo$getTemperatureScale() > -config.freezingConfig.getMaxPassiveFreezingPercent()) {
+                    if (player.thermoo$getTemperatureScale() < -config.freezingConfig.getMaxPassiveFreezingPercent()) {
                         return false;
                     }
 

--- a/src/main/java/com/github/thedeathlycow/frostiful/Frostiful.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/Frostiful.java
@@ -82,7 +82,7 @@ public class Frostiful implements ModInitializer {
                 (change, player) -> {
 
                     if (change > 0 && player.thermoo$isWarm()) {
-                        return false;
+                        return true;
                     }
 
                     FrostifulConfig config = getConfig();

--- a/src/main/java/com/github/thedeathlycow/frostiful/Frostiful.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/Frostiful.java
@@ -14,7 +14,7 @@ import com.github.thedeathlycow.frostiful.server.command.RootCommand;
 import com.github.thedeathlycow.frostiful.server.command.WindCommand;
 import com.github.thedeathlycow.frostiful.sound.FSoundEvents;
 import com.github.thedeathlycow.frostiful.survival.*;
-import com.github.thedeathlycow.frostiful.world.FGameRules;
+import com.github.thedeathlycow.frostiful.registry.FGameRules;
 import com.github.thedeathlycow.frostiful.world.gen.feature.FFeatures;
 import com.github.thedeathlycow.frostiful.world.gen.feature.FPlacedFeatures;
 import com.github.thedeathlycow.thermoo.api.temperature.event.EnvironmentControllerInitializeEvent;
@@ -87,11 +87,16 @@ public class Frostiful implements ModInitializer {
                     }
 
                     FrostifulConfig config = getConfig();
+
+                    if (player.thermoo$getTemperatureScale() > -config.freezingConfig.getMaxPassiveFreezingPercent()) {
+                        return false;
+                    }
+
                     boolean doPassiveFreezing = config.freezingConfig.doPassiveFreezing()
                             && player.getWorld().getGameRules().getBoolean(FGameRules.DO_PASSIVE_FREEZING);
 
                     if (doPassiveFreezing) {
-                        return player.thermoo$getTemperatureScale() > -config.freezingConfig.getMaxPassiveFreezingPercent();
+                        return true;
                     } else {
                         return FrostologyCloakItem.isWornBy(player);
                     }

--- a/src/main/java/com/github/thedeathlycow/frostiful/Frostiful.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/Frostiful.java
@@ -83,7 +83,7 @@ public class Frostiful implements ModInitializer {
         PlayerEnvironmentEvents.CAN_APPLY_PASSIVE_TEMPERATURE_CHANGE.register(
                 (change, player) -> {
 
-                    if (change > 0 && player.thermoo$isWarm()) {
+                    if (change > 0 || player.thermoo$isWarm()) {
                         return true;
                     }
 

--- a/src/main/java/com/github/thedeathlycow/frostiful/Frostiful.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/Frostiful.java
@@ -1,5 +1,6 @@
 package com.github.thedeathlycow.frostiful;
 
+import com.github.thedeathlycow.frostiful.compat.FrostifulIntegrations;
 import com.github.thedeathlycow.frostiful.config.FrostifulConfig;
 import com.github.thedeathlycow.frostiful.entity.effect.FPotions;
 import com.github.thedeathlycow.frostiful.entity.effect.FStatusEffects;
@@ -113,7 +114,12 @@ public class Frostiful implements ModInitializer {
                 EnvironmentControllerInitializeEvent.MODIFY_PHASE,
                 ModifyTemperatureController::new
         );
-        EnvironmentControllerInitializeEvent.EVENT.register(SoakingController::new);
+        EnvironmentControllerInitializeEvent.EVENT.register(
+                controller -> FrostifulIntegrations.isModLoaded(FrostifulIntegrations.SCORCHFUL_ID)
+                        ? controller
+                        : new SoakingController(controller)
+        );
+
     }
 
     public static FrostifulConfig getConfig() {

--- a/src/main/java/com/github/thedeathlycow/frostiful/Frostiful.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/Frostiful.java
@@ -82,8 +82,7 @@ public class Frostiful implements ModInitializer {
     private void registerThermooEventListeners() {
         PlayerEnvironmentEvents.CAN_APPLY_PASSIVE_TEMPERATURE_CHANGE.register(
                 (change, player) -> {
-
-                    if (change > 0 && player.thermoo$isWarm()) {
+                    if (change > 0) {
                         return true;
                     }
 

--- a/src/main/java/com/github/thedeathlycow/frostiful/Frostiful.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/Frostiful.java
@@ -5,6 +5,7 @@ import com.github.thedeathlycow.frostiful.entity.effect.FPotions;
 import com.github.thedeathlycow.frostiful.entity.effect.FStatusEffects;
 import com.github.thedeathlycow.frostiful.entity.loot.StrayLootTableModifier;
 import com.github.thedeathlycow.frostiful.item.FSmithingTemplateItem;
+import com.github.thedeathlycow.frostiful.item.FrostologyCloakItem;
 import com.github.thedeathlycow.frostiful.item.attribute.FrostResistantArmorTagApplicator;
 import com.github.thedeathlycow.frostiful.item.attribute.ItemAttributeLoader;
 import com.github.thedeathlycow.frostiful.particle.FParticleTypes;
@@ -86,13 +87,13 @@ public class Frostiful implements ModInitializer {
                     }
 
                     FrostifulConfig config = getConfig();
-                    boolean doPassiveFreezing = player.getWorld().getGameRules()
-                            .getBoolean(FGameRules.DO_PASSIVE_FREEZING);
+                    boolean doPassiveFreezing = config.freezingConfig.doPassiveFreezing()
+                            && player.getWorld().getGameRules().getBoolean(FGameRules.DO_PASSIVE_FREEZING);
 
-                    if (doPassiveFreezing && !config.freezingConfig.doPassiveFreezing()) {
-                        return false;
-                    } else {
+                    if (doPassiveFreezing) {
                         return player.thermoo$getTemperatureScale() > -config.freezingConfig.getMaxPassiveFreezingPercent();
+                    } else {
+                        return FrostologyCloakItem.isWornBy(player);
                     }
                 }
         );

--- a/src/main/java/com/github/thedeathlycow/frostiful/FrostifulClient.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/FrostifulClient.java
@@ -11,6 +11,7 @@ import com.github.thedeathlycow.frostiful.server.network.PointWindSpawnPacketLis
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.model.ModelLoadingRegistry;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRendererRegistry;

--- a/src/main/java/com/github/thedeathlycow/frostiful/compat/FrostifulIntegrations.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/compat/FrostifulIntegrations.java
@@ -14,6 +14,8 @@ public class FrostifulIntegrations {
 
     public static final String FABRIC_SEASONS_ID = "seasons";
 
+    public static final String SCORCHFUL_ID = "scorchful";
+
     public static boolean isHeartsRenderOverridden() {
         return isModLoaded(COLORFUL_HEARTS_ID) || isModLoaded(OVERFLOWING_BARS_ID);
     }

--- a/src/main/java/com/github/thedeathlycow/frostiful/config/group/CombatConfigGroup.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/config/group/CombatConfigGroup.java
@@ -11,7 +11,9 @@ public class CombatConfigGroup implements ConfigData {
 
 
     boolean doChillagerPatrols = true;
+
     boolean straysCarryFrostArrows = true;
+
     int heatDrainPerLevel = 210;
 
     double heatDrainEfficiency = 0.5;

--- a/src/main/java/com/github/thedeathlycow/frostiful/config/group/FreezingConfigGroup.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/config/group/FreezingConfigGroup.java
@@ -11,7 +11,7 @@ public class FreezingConfigGroup implements ConfigData {
 
     boolean doPassiveFreezing = true;
     boolean doWindSpawning = true;
-    WindSpawnStrategies windSpawnStrategy = WindSpawnStrategies.ENTITY;
+    WindSpawnStrategies windSpawnStrategy = WindSpawnStrategies.POINT;
     boolean spawnWindInAir = true;
     boolean windDestroysTorches = true;
     boolean doSnowPacking = true;

--- a/src/main/java/com/github/thedeathlycow/frostiful/entity/ChillagerEntity.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/entity/ChillagerEntity.java
@@ -6,7 +6,6 @@ import com.github.thedeathlycow.frostiful.registry.FEntityTypes;
 import com.github.thedeathlycow.frostiful.registry.FItems;
 import com.github.thedeathlycow.frostiful.sound.FSoundEvents;
 import com.github.thedeathlycow.thermoo.api.ThermooAttributes;
-import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LightningEntity;
 import net.minecraft.entity.SpawnReason;
@@ -68,11 +67,12 @@ public class ChillagerEntity extends PillagerEntity {
 
             frostologer.setPersistent();
             world.spawnEntityAndPassengers(frostologer);
-            ServerLivingEntityEvents.MOB_CONVERSION.invoker().onConversion(
-                    this,
-                    frostologer,
-                    false
-            );
+            // TODO: uncomment this line for 1.0.6
+//            ServerLivingEntityEvents.MOB_CONVERSION.invoker().onConversion(
+//                    this,
+//                    frostologer,
+//                    false
+//            );
             this.discard();
         } else {
             super.onStruckByLightning(world, lightning);

--- a/src/main/java/com/github/thedeathlycow/frostiful/entity/ChillagerEntity.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/entity/ChillagerEntity.java
@@ -6,6 +6,7 @@ import com.github.thedeathlycow.frostiful.registry.FEntityTypes;
 import com.github.thedeathlycow.frostiful.registry.FItems;
 import com.github.thedeathlycow.frostiful.sound.FSoundEvents;
 import com.github.thedeathlycow.thermoo.api.ThermooAttributes;
+import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LightningEntity;
 import net.minecraft.entity.SpawnReason;
@@ -67,6 +68,11 @@ public class ChillagerEntity extends PillagerEntity {
 
             frostologer.setPersistent();
             world.spawnEntityAndPassengers(frostologer);
+            ServerLivingEntityEvents.MOB_CONVERSION.invoker().onConversion(
+                    this,
+                    frostologer,
+                    false
+            );
             this.discard();
         } else {
             super.onStruckByLightning(world, lightning);

--- a/src/main/java/com/github/thedeathlycow/frostiful/mixins/client/DrippingWetPlayerMixin.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/mixins/client/DrippingWetPlayerMixin.java
@@ -1,6 +1,7 @@
 package com.github.thedeathlycow.frostiful.mixins.client;
 
 import com.github.thedeathlycow.frostiful.Frostiful;
+import com.github.thedeathlycow.frostiful.compat.FrostifulIntegrations;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.entity.EntityType;
@@ -46,6 +47,11 @@ public abstract class DrippingWetPlayerMixin extends LivingEntity {
     private void dripParticles(CallbackInfo ci) {
         World world = this.getWorld();
         if (world.isClient) { // only show particles on client to save bandwidth
+
+            // Scorchful does the same thing - let it handle this
+            if (FrostifulIntegrations.isModLoaded(FrostifulIntegrations.SCORCHFUL_ID)) {
+                return;
+            }
 
             // spectators should not drip
             if (this.isSpectator()) {

--- a/src/main/java/com/github/thedeathlycow/frostiful/registry/FGameRules.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/registry/FGameRules.java
@@ -1,4 +1,4 @@
-package com.github.thedeathlycow.frostiful.world;
+package com.github.thedeathlycow.frostiful.registry;
 
 import com.github.thedeathlycow.frostiful.Frostiful;
 import com.github.thedeathlycow.frostiful.util.TextStyles;

--- a/src/main/java/com/github/thedeathlycow/frostiful/survival/AmbientTemperatureController.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/survival/AmbientTemperatureController.java
@@ -82,7 +82,7 @@ public class AmbientTemperatureController extends EnvironmentControllerDecorator
 
         @Nullable AdaptedSeason season = AdaptedSeason.getCurrentSeason(world);
         BiomeCategory category = BiomeCategory.fromBiome(biome, season);
-        int temp = category.getTemperatureChange(world, season);
+        int temp = category.getTemperatureChange(world, pos, season);
         if (temp < 0) {
             return temp;
         }

--- a/src/main/java/com/github/thedeathlycow/frostiful/survival/AmbientTemperatureController.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/survival/AmbientTemperatureController.java
@@ -6,6 +6,7 @@ import com.github.thedeathlycow.frostiful.config.FrostifulConfig;
 import com.github.thedeathlycow.frostiful.tag.FBlockTags;
 import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentController;
 import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentControllerDecorator;
+import com.github.thedeathlycow.thermoo.api.temperature.TemperatureAware;
 import net.minecraft.block.BlockState;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.LivingEntity;
@@ -59,6 +60,11 @@ public class AmbientTemperatureController extends EnvironmentControllerDecorator
         }
 
         return warmth;
+    }
+
+    @Override
+    public int applyAwareHeat(TemperatureAware temperatureAware, int locationHeat) {
+        return temperatureAware.thermoo$isCold() ? locationHeat : 0;
     }
 
     @Override

--- a/src/main/java/com/github/thedeathlycow/frostiful/survival/BiomeCategory.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/survival/BiomeCategory.java
@@ -5,6 +5,8 @@ import com.github.thedeathlycow.frostiful.compat.AdaptedSeason;
 import com.github.thedeathlycow.frostiful.config.group.EnvironmentConfigGroup;
 import com.github.thedeathlycow.frostiful.tag.FBiomeTags;
 import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.LightType;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import org.jetbrains.annotations.Nullable;
@@ -58,11 +60,12 @@ public enum BiomeCategory {
         return AdaptedSeason.getSeasonallyShiftedBiomeCategory(season, category);
     }
 
-    public int getTemperatureChange(World world, @Nullable AdaptedSeason season) {
+    public int getTemperatureChange(World world, BlockPos pos, @Nullable AdaptedSeason season) {
         EnvironmentConfigGroup config = Frostiful.getConfig().environmentConfig;
         int change = this.temperatureChange.applyAsInt(config);
 
-        if (coldAtNight && world.isNight() && (!AdaptedSeason.isSummer(season) || config.isNightColdInSummer())) {
+        int sunlight = world.getLightLevel(LightType.SKY, pos) - world.getAmbientDarkness();
+        if (coldAtNight && sunlight < 0 && (!AdaptedSeason.isSummer(season) || config.isNightColdInSummer())) {
             change += config.getNightTemperatureShift();
         }
 

--- a/src/main/java/com/github/thedeathlycow/frostiful/survival/BiomeCategory.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/survival/BiomeCategory.java
@@ -23,6 +23,8 @@ public enum BiomeCategory {
     private static final float SNOW_TEMPERATURE = 0.15f;
     private static final float TAIGA_TEMPERATURE = 0.3f;
 
+    private static final int NIGHT_TIME_SURFACE_LIGHT = 4;
+
     private final ToIntFunction<EnvironmentConfigGroup> temperatureChange;
     private final boolean coldAtNight;
 
@@ -65,7 +67,7 @@ public enum BiomeCategory {
         int change = this.temperatureChange.applyAsInt(config);
 
         int sunlight = world.getLightLevel(LightType.SKY, pos) - world.getAmbientDarkness();
-        if (coldAtNight && sunlight < 0 && (!AdaptedSeason.isSummer(season) || config.isNightColdInSummer())) {
+        if (coldAtNight && sunlight <= NIGHT_TIME_SURFACE_LIGHT && (!AdaptedSeason.isSummer(season) || config.isNightColdInSummer())) {
             change += config.getNightTemperatureShift();
         }
 

--- a/src/main/java/com/github/thedeathlycow/frostiful/survival/EntityTemperatureController.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/survival/EntityTemperatureController.java
@@ -64,14 +64,11 @@ public class EntityTemperatureController extends EnvironmentControllerDecorator 
 
     @Override
     public int getEnvironmentTemperatureForPlayer(PlayerEntity player, int localTemperature) {
-        if (player.thermoo$isWarm() && localTemperature > 0) {
+        if (localTemperature > 0) {
             return controller.getEnvironmentTemperatureForPlayer(player, localTemperature);
         }
 
-        float modifier = 0f;
-        if (localTemperature < 0) {
-            modifier = getWetnessFreezeModifier(player);
-        }
+        float modifier = getWetnessFreezeModifier(player);
         return MathHelper.ceil(localTemperature * (1 + modifier));
     }
 

--- a/src/main/resources/assets/frostiful/lang/en_us.json
+++ b/src/main/resources/assets/frostiful/lang/en_us.json
@@ -118,11 +118,11 @@
   "commands.frostiful.root.set.success.multiple": "Rooted %s targets for %s ticks",
   
 
-  "gamerule.frostiful.doPassiveFreezing": "Do passive freezing",
-  "gamerule.maxSnowAccumulation": "Max snow accumulation",
+  "gamerule.frostiful.doPassiveFreezing": "Do environmental freezing",
+  "gamerule.frostiful.doPassiveFreezing.description": "If enabled, players will be slowly frozen by the environment over time. Players wearing a Cloak of Frostology are unaffected by this.",
   "gamerule.category.frostiful": "Frostiful",
 
-
+  
   "advancements.frostiful.adventure.obtain_frostology_cloak.title": "I'm the Frostologer Now!",
   "advancements.frostiful.adventure.obtain_frostology_cloak.description": "Obtain the Cloak of Frostology",
   "advancements.frostiful.adventure.find_frostologer_castle.title": "Packed In",

--- a/src/main/resources/data/frostiful/tags/items/warm_foods.json
+++ b/src/main/resources/data/frostiful/tags/items/warm_foods.json
@@ -92,6 +92,18 @@
         {
             "id": "spectrum:glistering_jelly_tea",
             "required": false
+        },
+        {
+            "id": "croptopia:pumpkin_spice_latte",
+            "required": false
+        },
+        {
+            "id": "croptopia:chili_relleno",
+            "required": false
+        },
+        {
+            "id": "croptopia:tea",
+            "required": false
         }
     ]
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -44,7 +44,7 @@
     ],
     "depends": {
         "fabricloader": ">=0.15.7",
-        "fabric-api": ">=0.92.0+1.20.1",
+        "fabric-api": ">=0.91.0",
         "minecraft": "~1.20.1",
         "thermoo": ">=2.1.2",
         "mm": ">=2.3",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -3,7 +3,7 @@
     "id": "frostiful",
     "version": "${version}",
     "name": "Frostiful",
-    "description": "A Frosty Vanilla+ Survival Experience - also try Scorchful!",
+    "description": "A Frosty Vanilla+ Survival Experience. Also try Scorchful!",
     "authors": [
         "TheDeathlyCow"
     ],

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -46,7 +46,7 @@
         "fabricloader": ">=0.15.7",
         "fabric-api": ">=0.92.0+1.20.1",
         "minecraft": "~1.20.1",
-        "thermoo": ">=2.1.0",
+        "thermoo": ">=2.1.2",
         "mm": ">=2.3",
         "java": ">=17"
     },

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -3,7 +3,7 @@
     "id": "frostiful",
     "version": "${version}",
     "name": "Frostiful",
-    "description": "A Frosty Vanilla+ Survival Experience",
+    "description": "A Frosty Vanilla+ Survival Experience - also try Scorchful!",
     "authors": [
         "TheDeathlyCow"
     ],
@@ -55,7 +55,9 @@
         "colorfulhearts": "<4.0.1",
         "thermoo": "<2.0.0"
     },
-    "suggests": {},
+    "suggests": {
+        "scorchful": "*"
+    },
     "accessWidener": "frostiful.accesswidener",
     "custom": {
         "cardinal-components": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -43,9 +43,9 @@
         "frostiful.mixins.json"
     ],
     "depends": {
-        "fabricloader": ">=0.14.21",
-        "fabric-api": "*",
-        "minecraft": ">=1.20",
+        "fabricloader": ">=0.15.7",
+        "fabric-api": ">=0.92.0+1.20.1",
+        "minecraft": "~1.20.1",
         "thermoo": ">=2.1.0",
         "mm": ">=2.3",
         "java": ">=17"


### PR DESCRIPTION
Closes #67 

* Updated required Fabric version
* ~~Invoke the new `MOB_CONVERSION` event when a Chillager transforms into a Frostologer~~ post poned to 1.0.6 to allow for better Quilt compatibility
* Fixed and simplified a few things to improve integration for Scorchful
* Changed the default wind spawn strategy to point, for performance 
* Added a description to the doPassiveFreezing game rule 
* Added Croptopia foods to the warm foods tag
* Fix torches killing everything with scorchful installed