### PR TITLE
Fix Powder Snow Walkable mixin compatibility

### DIFF
--- a/src/main/java/com/github/thedeathlycow/frostiful/mixins/block/PowderSnowWalkableMixin.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/mixins/block/PowderSnowWalkableMixin.java
@@ -5,33 +5,26 @@ import net.minecraft.block.PowderSnowBlock;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.registry.tag.EntityTypeTags;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(PowderSnowBlock.class)
-public class PowderSnowWalkableMixin {
-
-
+public abstract class PowderSnowWalkableMixin {
     @Inject(
             method = "canWalkOnPowderSnow",
             at = @At("HEAD"),
             cancellable = true
     )
-    private static void canWalkOnPowderSnowBootTag(Entity entity, CallbackInfoReturnable<Boolean> cir) {
-        if (!entity.getType().isIn(EntityTypeTags.POWDER_SNOW_WALKABLE_MOBS) && (entity instanceof LivingEntity livingEntity)) {
-
+    private static void checkPowderSnowWalkableItemTag(Entity entity, CallbackInfoReturnable<Boolean> cir) {
+        if (entity instanceof LivingEntity livingEntity) {
             for (ItemStack stack : livingEntity.getArmorItems()) {
                 if (!stack.isEmpty() && stack.isIn(FItemTags.POWDER_SNOW_WALKABLE)) {
                     cir.setReturnValue(true);
                     return;
                 }
             }
-
-            cir.setReturnValue(false);
         }
     }
-
 }

--- a/src/main/java/com/github/thedeathlycow/frostiful/mixins/block/PowderSnowWalkableMixin.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/mixins/block/PowderSnowWalkableMixin.java
@@ -4,15 +4,21 @@ import com.github.thedeathlycow.frostiful.registry.tag.FItemTags;
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import net.minecraft.block.PowderSnowBlock;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(PowderSnowBlock.class)
 public abstract class PowderSnowWalkableMixin {
+
+    @Unique
+    private static final EquipmentSlot[] ALLOWED_SLOTS = new EquipmentSlot[]{EquipmentSlot.FEET, EquipmentSlot.BODY};
+
     @ModifyReturnValue(
             method = "canWalkOnPowderSnow",
             at = @At(
@@ -31,7 +37,8 @@ public abstract class PowderSnowWalkableMixin {
     )
     private static void checkPowderSnowWalkableItemTag(Entity entity, CallbackInfoReturnable<Boolean> cir) {
         if (entity instanceof LivingEntity livingEntity) {
-            for (ItemStack stack : livingEntity.getArmorItems()) {
+            for (EquipmentSlot slot : ALLOWED_SLOTS) {
+                ItemStack stack = livingEntity.getEquippedStack(slot);
                 if (!stack.isEmpty() && stack.isIn(FItemTags.POWDER_SNOW_WALKABLE)) {
                     cir.setReturnValue(true);
                     return;

--- a/src/main/java/com/github/thedeathlycow/frostiful/mixins/block/PowderSnowWalkableMixin.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/mixins/block/PowderSnowWalkableMixin.java
@@ -1,6 +1,7 @@
 package com.github.thedeathlycow.frostiful.mixins.block;
 
 import com.github.thedeathlycow.frostiful.registry.tag.FItemTags;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import net.minecraft.block.PowderSnowBlock;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
@@ -12,6 +13,17 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(PowderSnowBlock.class)
 public abstract class PowderSnowWalkableMixin {
+    @ModifyReturnValue(
+            method = "canWalkOnPowderSnow",
+            at = @At(
+                    value = "RETURN",
+                    ordinal = 1
+            )
+    )
+    private static boolean ignoreHardCodedLeatherBootsCheck(boolean original) {
+        return false;
+    }
+
     @Inject(
             method = "canWalkOnPowderSnow",
             at = @At("HEAD"),


### PR DESCRIPTION
Fixes #121 by separating logic for checking tag and ignoring the hard-coded leather boots check into two separate mixin methods. 

Also fixes a bug that allowed for walkable items in slots other than the body and feet to allow for powder snow walking. 