### PR TITLE
Fix Ice Skates recipe being wrongly granted

### DIFF
--- a/src/main/resources/data/frostiful/advancement/recipes/combat/armor/ice_skates.json
+++ b/src/main/resources/data/frostiful/advancement/recipes/combat/armor/ice_skates.json
@@ -11,7 +11,7 @@
             "conditions": {
                 "items": [
                     {
-                        "item": [
+                        "items": [
                             "frostiful:fur_boots"
                         ]
                     }


### PR DESCRIPTION
Typo in file caused any `inventory_changed` event to trigger the recipe grant popup for ice skates.