### PR TITLE
Freezing Peaks

### DIFF
--- a/src/main/java/com/github/thedeathlycow/frostiful/registry/tag/SeasonalBiomeTags.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/registry/tag/SeasonalBiomeTags.java
@@ -7,28 +7,33 @@ import net.minecraft.world.biome.Biome;
 public record SeasonalBiomeTags(
         TagKey<Biome> freezing,
         TagKey<Biome> cold,
-        TagKey<Biome> cool
+        TagKey<Biome> cool,
+        TagKey<Biome> normal
 ) {
 
     private static final SeasonalBiomeTags SPRING_TAGS = new SeasonalBiomeTags(
             FBiomeTags.register("temperature/spring/freezing"),
             FBiomeTags.register("temperature/spring/cold"),
-            FBiomeTags.register("temperature/spring/cool")
+            FBiomeTags.register("temperature/spring/cool"),
+            FBiomeTags.register("temperature/spring/normal")
     );
     private static final SeasonalBiomeTags SUMMER_TAGS = new SeasonalBiomeTags(
             FBiomeTags.register("temperature/summer/freezing"),
             FBiomeTags.register("temperature/summer/cold"),
-            FBiomeTags.register("temperature/summer/cool")
+            FBiomeTags.register("temperature/summer/cool"),
+            FBiomeTags.register("temperature/summer/normal")
     );
     private static final SeasonalBiomeTags AUTUMN_TAGS = new SeasonalBiomeTags(
             FBiomeTags.register("temperature/autumn/freezing"),
             FBiomeTags.register("temperature/autumn/cold"),
-            FBiomeTags.register("temperature/autumn/cool")
+            FBiomeTags.register("temperature/autumn/cool"),
+            FBiomeTags.register("temperature/autumn/normal")
     );
     private static final SeasonalBiomeTags WINTER_TAGS = new SeasonalBiomeTags(
             FBiomeTags.register("temperature/winter/freezing"),
             FBiomeTags.register("temperature/winter/cold"),
-            FBiomeTags.register("temperature/winter/cool")
+            FBiomeTags.register("temperature/winter/cool"),
+            FBiomeTags.register("temperature/winter/normal")
     );
 
     /**

--- a/src/main/java/com/github/thedeathlycow/frostiful/survival/BiomeCategory.java
+++ b/src/main/java/com/github/thedeathlycow/frostiful/survival/BiomeCategory.java
@@ -41,7 +41,7 @@ public enum BiomeCategory {
         SeasonalBiomeTags tags = SeasonalBiomeTags.forSeason(season);
 
         BiomeCategory category;
-        if (biomeEntry.isIn(FBiomeTags.FREEZING_BLACKLIST_BIOMES)) {
+        if (biomeEntry.isIn(tags.normal()) || biomeEntry.isIn(FBiomeTags.FREEZING_BLACKLIST_BIOMES)) {
             category = NORMAL;
         } else if (biomeEntry.isIn(tags.freezing())) {
             category = FREEZING;

--- a/src/main/resources/data/frostiful/tags/worldgen/biome/temperature/autumn/normal.json
+++ b/src/main/resources/data/frostiful/tags/worldgen/biome/temperature/autumn/normal.json
@@ -1,6 +1,6 @@
 {
     "replace": false,
     "values": [
-        "#frostiful:temperature/spring/normal"
+        "minecraft:stony_peaks"
     ]
 }

--- a/src/main/resources/data/frostiful/tags/worldgen/biome/temperature/autumn/normal.json
+++ b/src/main/resources/data/frostiful/tags/worldgen/biome/temperature/autumn/normal.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+        "#frostiful:temperature/spring/normal"
+    ]
+}

--- a/src/main/resources/data/frostiful/tags/worldgen/biome/temperature/spring/cold.json
+++ b/src/main/resources/data/frostiful/tags/worldgen/biome/temperature/spring/cold.json
@@ -3,6 +3,7 @@
     "values": [
         "#c:is_snowy",
         "#c:is_snowy_plains",
+        "#c:is_mountain/slope",
         {
             "required": false,
             "id": "#frostiful:cold_biomes"

--- a/src/main/resources/data/frostiful/tags/worldgen/biome/temperature/spring/freezing.json
+++ b/src/main/resources/data/frostiful/tags/worldgen/biome/temperature/spring/freezing.json
@@ -2,6 +2,7 @@
     "replace": false,
     "values": [
         "#c:is_icy",
+        "#c:is_mountain/peak",
         {
             "required": false,
             "id": "#frostiful:freezing_biomes"

--- a/src/main/resources/data/frostiful/tags/worldgen/biome/temperature/spring/normal.json
+++ b/src/main/resources/data/frostiful/tags/worldgen/biome/temperature/spring/normal.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+        "minecraft:stony_peaks"
+    ]
+}

--- a/src/main/resources/data/frostiful/tags/worldgen/biome/temperature/summer/normal.json
+++ b/src/main/resources/data/frostiful/tags/worldgen/biome/temperature/summer/normal.json
@@ -1,0 +1,7 @@
+{
+    "replace": false,
+    "values": [
+        "#frostiful:temperature/spring/normal",
+        "#frostiful:temperature/spring/cool"
+    ]
+}

--- a/src/main/resources/data/frostiful/tags/worldgen/biome/temperature/summer/normal.json
+++ b/src/main/resources/data/frostiful/tags/worldgen/biome/temperature/summer/normal.json
@@ -1,7 +1,6 @@
 {
     "replace": false,
     "values": [
-        "#frostiful:temperature/spring/normal",
-        "#frostiful:temperature/spring/cool"
+        "minecraft:stony_peaks"
     ]
 }

--- a/src/main/resources/data/frostiful/tags/worldgen/biome/temperature/winter/normal.json
+++ b/src/main/resources/data/frostiful/tags/worldgen/biome/temperature/winter/normal.json
@@ -1,0 +1,4 @@
+{
+    "replace": false,
+    "values": []
+}


### PR DESCRIPTION
Resolves #154 

Mountain Peaks are now freezing year round, with the exception of Stony Peaks, which are now only freezing in the winter. To accommodate stony peaks, a new "normal" season tag category was made for biomes that are forced to have normal temperature, but only for that season. 