### PR TITLE
Ice Speed Enchantment

### DIFF
--- a/src/main/resources/assets/frostiful/lang/en_us.json
+++ b/src/main/resources/assets/frostiful/lang/en_us.json
@@ -260,9 +260,11 @@
   "enchantment.frostiful.enervation": "Enervation",
   "enchantment.frostiful.enervation.desc": "Steals heat from cold enemies when attacking",
   "enchantment.frostiful.ice_breaker": "Ice Breaker",
-  "enchantment.frostiful.ice_breaker.desc": "Increases the damage from attacking enemies frozen in Ice",
+  "enchantment.frostiful.ice_breaker.desc": "Increases the damage from attacking enemies frozen in ice",
   "enchantment.frostiful.frozen_touch_curse": "Curse of Frozen Touch",
   "enchantment.frostiful.frozen_touch_curse.desc": "Transfers heat from you to your enemies when attacking",
+  "enchantment.frostiful.ice_speed": "Ice Speed",
+  "enchantment.frostiful.ice_speed.desc": "Increases skating speed on ice",
   
   
   "frostiful.tip.freezing_wind_extinguishes_fire": "Freezing Wind will blow out open flames",

--- a/src/main/resources/data/frostiful/enchantment/ice_speed.json
+++ b/src/main/resources/data/frostiful/enchantment/ice_speed.json
@@ -1,0 +1,168 @@
+{
+    "anvil_cost": 8,
+    "description": {
+        "translate": "enchantment.frostiful.ice_speed"
+    },
+    "max_level": 3,
+    "min_cost": {
+        "base": 10,
+        "per_level_above_first": 10
+    },
+    "max_cost": {
+        "base": 25,
+        "per_level_above_first": 10
+    },
+    "slots": [
+        "feet"
+    ],
+    "primary_items": "#frostiful:enchantable/ice_skates",
+    "supported_items": "#frostiful:enchantable/ice_skates",
+    "weight": 2,
+    "effects": {
+        "minecraft:location_changed": [
+            {
+                "effect": {
+                    "type": "minecraft:all_of",
+                    "effects": [
+                        {
+                            "type": "minecraft:attribute",
+                            "amount": {
+                                "type": "minecraft:linear",
+                                "base": 0.0405,
+                                "per_level_above_first": 0.0105
+                            },
+                            "attribute": "minecraft:movement_speed",
+                            "id": "frostiful:enchantment.ice_speed",
+                            "operation": "add_value"
+                        },
+                        {
+                            "type": "minecraft:attribute",
+                            "amount": 1,
+                            "attribute": "minecraft:movement_efficiency",
+                            "id": "frostiful:enchantment.ice_speed",
+                            "operation": "add_value"
+                        }
+                    ]
+                },
+                "requirements": {
+                    "condition": "minecraft:all_of",
+                    "terms": [
+                        {
+                            "condition": "minecraft:inverted",
+                            "term": {
+                                "condition": "minecraft:entity_properties",
+                                "entity": "this",
+                                "predicate": {
+                                    "vehicle": {}
+                                }
+                            }
+                        },
+                        {
+                            "condition": "minecraft:any_of",
+                            "terms": [
+                                {
+                                    "condition": "minecraft:all_of",
+                                    "terms": [
+                                        {
+                                            "active": true,
+                                            "condition": "minecraft:enchantment_active_check"
+                                        },
+                                        {
+                                            "condition": "minecraft:entity_properties",
+                                            "entity": "this",
+                                            "predicate": {
+                                                "flags": {
+                                                    "is_flying": false
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "condition": "minecraft:any_of",
+                                            "terms": [
+                                                {
+                                                    "condition": "minecraft:entity_properties",
+                                                    "entity": "this",
+                                                    "predicate": {
+                                                        "movement_affected_by": {
+                                                            "block": {
+                                                                "blocks": "#frostiful:ice_speed_blocks"
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "condition": "minecraft:entity_properties",
+                                                    "entity": "this",
+                                                    "predicate": {
+                                                        "flags": {
+                                                            "is_on_ground": false
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "condition": "minecraft:all_of",
+                                    "terms": [
+                                        {
+                                            "active": false,
+                                            "condition": "minecraft:enchantment_active_check"
+                                        },
+                                        {
+                                            "condition": "minecraft:entity_properties",
+                                            "entity": "this",
+                                            "predicate": {
+                                                "flags": {
+                                                    "is_flying": false
+                                                },
+                                                "movement_affected_by": {
+                                                    "block": {
+                                                        "blocks": "#frostiful:ice_speed_blocks"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "effect": {
+                    "type": "minecraft:change_item_damage",
+                    "amount": 1
+                },
+                "requirements": {
+                    "condition": "minecraft:all_of",
+                    "terms": [
+                        {
+                            "chance": {
+                                "type": "minecraft:enchantment_level",
+                                "amount": 0.04
+                            },
+                            "condition": "minecraft:random_chance"
+                        },
+                        {
+                            "condition": "minecraft:entity_properties",
+                            "entity": "this",
+                            "predicate": {
+                                "flags": {
+                                    "is_on_ground": true
+                                },
+                                "movement_affected_by": {
+                                    "block": {
+                                        "blocks": "#frostiful:ice_speed_blocks"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/src/main/resources/data/frostiful/tags/block/ice_speed_blocks.json
+++ b/src/main/resources/data/frostiful/tags/block/ice_speed_blocks.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "#minecraft:ice"
+    ]
+}

--- a/src/main/resources/data/frostiful/tags/item/enchantable/ice_skates.json
+++ b/src/main/resources/data/frostiful/tags/item/enchantable/ice_skates.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "#frostiful:ice_skates"
+    ]
+}

--- a/src/main/resources/data/minecraft/tags/enchantment/non_treasure.json
+++ b/src/main/resources/data/minecraft/tags/enchantment/non_treasure.json
@@ -2,6 +2,7 @@
     "replace": false,
     "values": [
         "frostiful:enervation",
-        "frostiful:ice_breaker"
+        "frostiful:ice_breaker",
+        "frostiful:ice_speed"
     ]
 }


### PR DESCRIPTION
Add a new enchantment for the Ice Skates called 'Ice Speed'. This enchantment works similarly to Soul Speed, but applies only when on ice. It is primarily intended to synergize with the Spear, allowing the player to achieve very high speeds for massive damage, with greater control than an ice boat.